### PR TITLE
browser: do not allow for opening a new tab / window

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -49,6 +49,11 @@ impl QServoBrowser {
 
         for (webview_id, msg) in events {
             match msg {
+                // Do not allow for opening a new tab / window
+                // Not handling this crashes the webview
+                EmbedderMsg::AllowOpeningWebView(ipc) => {
+                    ipc.send(false).unwrap();
+                }
                 EmbedderMsg::AllowNavigationRequest(pipeline_id, url) => {
                     if let Some(_webview_id) = webview_id {
                         self.event_queue


### PR DESCRIPTION
If we don't handle this the tab crashes if you click on a link that attempts to open a new tab or window.