### PR TITLE
Minor improvements to README and shell.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ $ rustup default nightly-2024-02-01
 $ cargo run --release
 ```
 
+Note that this demo currently supports Wayland only, not X11.
+
 ## Debugging
 
 To make sure, that Qt picks the correct OpenGL driver, use the `QSG_INFO=1` variable. For hardware acceleration to work, the driver name should **not** contain `llvmpipe`.

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ let
 	llvmPackages = llvmPackages_14; # servo/servo#31059
 	stdenv = stdenvAdapters.useMoldLinker llvmPackages.stdenv;
 in
-	llvmPackages.stdenv.mkDerivation {
+	stdenv.mkDerivation {
 		name = "cxx-qt-servo-webview";
 
 		buildInputs = [

--- a/shell.nix
+++ b/shell.nix
@@ -30,6 +30,8 @@ in
 			rustup
 			taplo
 			llvmPackages.bintools
+			llvmPackages.llvm
+			llvmPackages.libclang
 			udev
 			cmake dbus gcc git pkg-config which llvm perl yasm m4
 			pkgs_gnumake_4_3.gnumake # servo/mozjs#375
@@ -37,9 +39,9 @@ in
 			qt6.full
 			stdenv.cc.cc.lib
 			mold
-			libclang
 		];
 		LD_LIBRARY_PATH = lib.makeLibraryPath [zlib xorg.libXcursor xorg.libXrandr xorg.libXi libxkbcommon vulkan-loader stdenv.cc.cc];
+		LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
 		shellHook = ''
 			# see https://github.com/servo/mozjs/blob/20f7934762a6a1d4751353c8d024a0185ba85547/shell.nix#L11-L16

--- a/shell.nix
+++ b/shell.nix
@@ -6,10 +6,11 @@
 with import <nixpkgs> {};
 with import (fetchTarball "https://github.com/nix-community/nixGL/archive/489d6b095ab9d289fe11af0219a9ff00fe87c7c5.tar.gz") { enable32bits = false; };
 let
-	llvmPackages = llvmPackages_14;
-	stdenv = stdenvAdapters.useMoldLinker clangStdenv;
+	pkgs_gnumake_4_3 = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/6adf48f53d819a7b6e15672817fa1e78e5f4e84f.tar.gz") {};
+	llvmPackages = llvmPackages_14; # servo/servo#31059
+	stdenv = stdenvAdapters.useMoldLinker llvmPackages.stdenv;
 in
-	stdenv.mkDerivation {
+	llvmPackages.stdenv.mkDerivation {
 		name = "cxx-qt-servo-webview";
 
 		buildInputs = [
@@ -31,7 +32,7 @@ in
 			llvmPackages.bintools
 			udev
 			cmake dbus gcc git pkg-config which llvm perl yasm m4
-			gnumake
+			pkgs_gnumake_4_3.gnumake # servo/mozjs#375
 			libGL
 			qt6.full
 			stdenv.cc.cc.lib


### PR DESCRIPTION
While testing this, I ran into a few minor issues:

- the demo can only be built in release mode, due to [servo/servo#31059](https://github.com/servo/servo/issues/31059)
- the build takes over 11 minutes with gnumake 4.4, due to [servo/mozjs#375](https://github.com/servo/mozjs/issues/375)
- the demo panics unless I switch to Wayland, because I normally use X11 (“Failed to bootstrap native connection: NoCurrentConnection” at src/renderer.rs:267)

This patch adds Servo’s workarounds for the first two in shell.nix, and documents the third in the README.